### PR TITLE
pb - add placeholder pages for Index, Edit, Create for Articles

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -54,7 +54,7 @@ function App() {
         </>
       )}
 
-       {hasRole(currentUser, "ROLE_USER") && (
+      {hasRole(currentUser, "ROLE_USER") && (
         <>
           <Route exact path="/articles" element={<ArticlesIndexPage />} />
         </>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -11,6 +11,10 @@ import RestaurantIndexPage from "main/pages/Restaurants/RestaurantIndexPage";
 import RestaurantCreatePage from "main/pages/Restaurants/RestaurantCreatePage";
 import RestaurantEditPage from "main/pages/Restaurants/RestaurantEditPage";
 
+import ArticlesIndexPage from "main/pages/Articles/ArticlesIndexPage";
+import ArticlesCreatePage from "main/pages/Articles/ArticlesCreatePage";
+import ArticlesEditPage from "main/pages/Articles/ArticlesEditPage";
+
 import PlaceholderIndexPage from "main/pages/Placeholder/PlaceholderIndexPage";
 import PlaceholderCreatePage from "main/pages/Placeholder/PlaceholderCreatePage";
 import PlaceholderEditPage from "main/pages/Placeholder/PlaceholderEditPage";
@@ -49,6 +53,27 @@ function App() {
           />
         </>
       )}
+
+       {hasRole(currentUser, "ROLE_USER") && (
+        <>
+          <Route exact path="/articles" element={<ArticlesIndexPage />} />
+        </>
+      )}
+      {hasRole(currentUser, "ROLE_ADMIN") && (
+        <>
+          <Route
+            exact
+            path="/articles/edit/:id"
+            element={<ArticlesEditPage />}
+          />
+          <Route
+            exact
+            path="/articles/create"
+            element={<ArticlesCreatePage />}
+          />
+        </>
+      )}
+
       {hasRole(currentUser, "ROLE_USER") && (
         <>
           <Route exact path="/restaurants" element={<RestaurantIndexPage />} />

--- a/frontend/src/fixtures/articleFixtures.js
+++ b/frontend/src/fixtures/articleFixtures.js
@@ -1,0 +1,39 @@
+const articleFixtures = {
+  oneArticle: {
+    "id": 1,
+    "title": "Why are there so many daffodils in Jersey?",
+    "url": "https://www.bbc.com/news/articles/cx2l20rwxgxo",
+    "explanation": "Explaining the daffodil bloom",
+    "email": "prishabobde@gmail.com",
+    "dateAdded": "2024-12-12T05:06:05"
+  },
+  threeArticles: [
+  {
+    "id": 1,
+    "title": "Why are there so many daffodils in Jersey?",
+    "url": "https://www.bbc.com/news/articles/cx2l20rwxgxo",
+    "explanation": "Explaining the daffodil bloom",
+    "email": "prishabobde@gmail.com",
+    "dateAdded": "2024-12-12T05:06:05"
+  },
+  {
+    "id": 2,
+    "title": "Watch: Yosemite waterfall turns molten orange",
+    "url": "https://www.bbc.com/news/videos/c4gjmp9de59o",
+    "explanation": "Firefall video",
+    "email": "prishabobde@ucsb.edu",
+    "dateAdded": "2025-09-12T05:06:05"
+  },
+  {
+    "id": 3,
+    "title": "The lost art of letter writing uniting generations",
+    "url": "https://www.bbc.com/news/articles/cpqw7z87qv3o",
+    "explanation": "Penpals across generations",
+    "email": "prishabobde@ucsb.edu",
+    "dateAdded": "2026-10-11T05:06:04"
+  }
+]
+
+};
+
+export { articleFixtures };

--- a/frontend/src/fixtures/articleFixtures.js
+++ b/frontend/src/fixtures/articleFixtures.js
@@ -1,39 +1,38 @@
 const articleFixtures = {
   oneArticle: {
-    "id": 1,
-    "title": "Why are there so many daffodils in Jersey?",
-    "url": "https://www.bbc.com/news/articles/cx2l20rwxgxo",
-    "explanation": "Explaining the daffodil bloom",
-    "email": "prishabobde@gmail.com",
-    "dateAdded": "2024-12-12T05:06:05"
+    id: 1,
+    title: "Why are there so many daffodils in Jersey?",
+    url: "https://www.bbc.com/news/articles/cx2l20rwxgxo",
+    explanation: "Explaining the daffodil bloom",
+    email: "prishabobde@gmail.com",
+    dateAdded: "2024-12-12T05:06:05",
   },
   threeArticles: [
-  {
-    "id": 1,
-    "title": "Why are there so many daffodils in Jersey?",
-    "url": "https://www.bbc.com/news/articles/cx2l20rwxgxo",
-    "explanation": "Explaining the daffodil bloom",
-    "email": "prishabobde@gmail.com",
-    "dateAdded": "2024-12-12T05:06:05"
-  },
-  {
-    "id": 2,
-    "title": "Watch: Yosemite waterfall turns molten orange",
-    "url": "https://www.bbc.com/news/videos/c4gjmp9de59o",
-    "explanation": "Firefall video",
-    "email": "prishabobde@ucsb.edu",
-    "dateAdded": "2025-09-12T05:06:05"
-  },
-  {
-    "id": 3,
-    "title": "The lost art of letter writing uniting generations",
-    "url": "https://www.bbc.com/news/articles/cpqw7z87qv3o",
-    "explanation": "Penpals across generations",
-    "email": "prishabobde@ucsb.edu",
-    "dateAdded": "2026-10-11T05:06:04"
-  }
-]
-
+    {
+      id: 1,
+      title: "Why are there so many daffodils in Jersey?",
+      url: "https://www.bbc.com/news/articles/cx2l20rwxgxo",
+      explanation: "Explaining the daffodil bloom",
+      email: "prishabobde@gmail.com",
+      dateAdded: "2024-12-12T05:06:05",
+    },
+    {
+      id: 2,
+      title: "Watch: Yosemite waterfall turns molten orange",
+      url: "https://www.bbc.com/news/videos/c4gjmp9de59o",
+      explanation: "Firefall video",
+      email: "prishabobde@ucsb.edu",
+      dateAdded: "2025-09-12T05:06:05",
+    },
+    {
+      id: 3,
+      title: "The lost art of letter writing uniting generations",
+      url: "https://www.bbc.com/news/articles/cpqw7z87qv3o",
+      explanation: "Penpals across generations",
+      email: "prishabobde@ucsb.edu",
+      dateAdded: "2026-10-11T05:06:04",
+    },
+  ],
 };
 
 export { articleFixtures };

--- a/frontend/src/main/components/Articles/ArticleForm.jsx
+++ b/frontend/src/main/components/Articles/ArticleForm.jsx
@@ -5,7 +5,7 @@ import { useNavigate } from "react-router";
 function ArticleForm({
   initialContents,
   submitAction,
-  buttonLabel = "Create"
+  buttonLabel = "Create",
 }) {
   // Stryker disable all
   const {

--- a/frontend/src/main/components/Articles/ArticleForm.jsx
+++ b/frontend/src/main/components/Articles/ArticleForm.jsx
@@ -19,6 +19,14 @@ function ArticleForm({
 
   const testIdPrefix = "ArticleForm";
 
+  // For explanation, see: https://stackoverflow.com/questions/3143070/javascript-regex-iso-datetime
+  // Note that even this complex regex may still need some tweaks
+
+  // Stryker disable Regex
+  const isodate_regex =
+    /(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+)|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d)|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d)/i;
+  // Stryker restore Regex
+
   return (
     <Form onSubmit={handleSubmit(submitAction)}>
       {initialContents && (
@@ -70,6 +78,56 @@ function ArticleForm({
           {errors.url?.message}
         </Form.Control.Feedback>
       </Form.Group>
+
+       <Form.Group className="mb-3">
+        <Form.Label htmlFor="explanation">Explanation</Form.Label>
+        <Form.Control
+          data-testid={testIdPrefix + "-explanation"}
+          id="explanation"
+          type="text"
+          isInvalid={Boolean(errors.explanation)}
+          {...register("explanation", {
+            required: "Explanation is required.",
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.explanation?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+       <Form.Group className="mb-3">
+        <Form.Label htmlFor="email">Email</Form.Label>
+        <Form.Control
+          data-testid={testIdPrefix + "-email"}
+          id="email"
+          type="email"
+          isInvalid={Boolean(errors.email)}
+          {...register("email", {
+            required: "Email is required.",
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.email?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Form.Group className="mb-3">
+            <Form.Label htmlFor="dateAdded">Date Added(iso format)</Form.Label>
+            <Form.Control
+              data-testid={testIdPrefix + "-dateAdded"}
+              id="dateAdded"
+              type="datetime-local"
+              isInvalid={Boolean(errors.dateAdded)}
+              {...register("dateAdded", {
+                required: true,
+                pattern: isodate_regex,
+              })}
+            />
+            <Form.Control.Feedback type="invalid">
+              {errors.dateAdded && "Date Added is required. "}
+            </Form.Control.Feedback>
+      </Form.Group>
+
 
       <Button type="submit" data-testid={testIdPrefix + "-submit"}>
         {buttonLabel}

--- a/frontend/src/main/components/Articles/ArticleForm.jsx
+++ b/frontend/src/main/components/Articles/ArticleForm.jsx
@@ -79,7 +79,7 @@ function ArticleForm({
         </Form.Control.Feedback>
       </Form.Group>
 
-       <Form.Group className="mb-3">
+      <Form.Group className="mb-3">
         <Form.Label htmlFor="explanation">Explanation</Form.Label>
         <Form.Control
           data-testid={testIdPrefix + "-explanation"}
@@ -95,7 +95,7 @@ function ArticleForm({
         </Form.Control.Feedback>
       </Form.Group>
 
-       <Form.Group className="mb-3">
+      <Form.Group className="mb-3">
         <Form.Label htmlFor="email">Email</Form.Label>
         <Form.Control
           data-testid={testIdPrefix + "-email"}
@@ -112,22 +112,21 @@ function ArticleForm({
       </Form.Group>
 
       <Form.Group className="mb-3">
-            <Form.Label htmlFor="dateAdded">Date Added(iso format)</Form.Label>
-            <Form.Control
-              data-testid={testIdPrefix + "-dateAdded"}
-              id="dateAdded"
-              type="datetime-local"
-              isInvalid={Boolean(errors.dateAdded)}
-              {...register("dateAdded", {
-                required: true,
-                pattern: isodate_regex,
-              })}
-            />
-            <Form.Control.Feedback type="invalid">
-              {errors.dateAdded && "Date Added is required. "}
-            </Form.Control.Feedback>
+        <Form.Label htmlFor="dateAdded">Date Added(iso format)</Form.Label>
+        <Form.Control
+          data-testid={testIdPrefix + "-dateAdded"}
+          id="dateAdded"
+          type="datetime-local"
+          isInvalid={Boolean(errors.dateAdded)}
+          {...register("dateAdded", {
+            required: true,
+            pattern: isodate_regex,
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.dateAdded && "Date Added is required. "}
+        </Form.Control.Feedback>
       </Form.Group>
-
 
       <Button type="submit" data-testid={testIdPrefix + "-submit"}>
         {buttonLabel}

--- a/frontend/src/main/components/Articles/ArticleForm.jsx
+++ b/frontend/src/main/components/Articles/ArticleForm.jsx
@@ -1,0 +1,88 @@
+import { Button, Form } from "react-bootstrap";
+import { useForm } from "react-hook-form";
+import { useNavigate } from "react-router";
+
+function ArticleForm({
+  initialContents,
+  submitAction,
+  buttonLabel = "Create"
+}) {
+  // Stryker disable all
+  const {
+    register,
+    formState: { errors },
+    handleSubmit,
+  } = useForm({ defaultValues: initialContents || {} });
+  // Stryker restore all
+
+  const navigate = useNavigate();
+
+  const testIdPrefix = "ArticleForm";
+
+  return (
+    <Form onSubmit={handleSubmit(submitAction)}>
+      {initialContents && (
+        <Form.Group className="mb-3">
+          <Form.Label htmlFor="id">Id</Form.Label>
+          <Form.Control
+            data-testid={testIdPrefix + "-id"}
+            id="id"
+            type="text"
+            {...register("id")}
+            value={initialContents.id}
+            disabled
+          />
+        </Form.Group>
+      )}
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="title">Title</Form.Label>
+        <Form.Control
+          data-testid={testIdPrefix + "-title"}
+          id="title"
+          type="text"
+          isInvalid={Boolean(errors.title)}
+          {...register("title", {
+            required: "Title is required.",
+            maxLength: {
+              value: 255,
+              message: "Max length 255 characters",
+            },
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.title?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="url">Url</Form.Label>
+        <Form.Control
+          data-testid={testIdPrefix + "-url"}
+          id="url"
+          type="text"
+          isInvalid={Boolean(errors.url)}
+          {...register("url", {
+            required: "Url is required.",
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.url?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Button type="submit" data-testid={testIdPrefix + "-submit"}>
+        {buttonLabel}
+      </Button>
+      <Button
+        variant="Secondary"
+        onClick={() => navigate(-1)}
+        data-testid={testIdPrefix + "-cancel"}
+      >
+        Cancel
+      </Button>
+    </Form>
+  );
+}
+
+export default ArticleForm;

--- a/frontend/src/main/components/Articles/ArticleForm.jsx
+++ b/frontend/src/main/components/Articles/ArticleForm.jsx
@@ -66,7 +66,6 @@ function ArticleForm({
       <Form.Group className="mb-3">
         <Form.Label htmlFor="url">Url</Form.Label>
         <Form.Control
-          data-testid={testIdPrefix + "-url"}
           id="url"
           type="text"
           isInvalid={Boolean(errors.url)}
@@ -82,7 +81,6 @@ function ArticleForm({
       <Form.Group className="mb-3">
         <Form.Label htmlFor="explanation">Explanation</Form.Label>
         <Form.Control
-          data-testid={testIdPrefix + "-explanation"}
           id="explanation"
           type="text"
           isInvalid={Boolean(errors.explanation)}
@@ -98,7 +96,6 @@ function ArticleForm({
       <Form.Group className="mb-3">
         <Form.Label htmlFor="email">Email</Form.Label>
         <Form.Control
-          data-testid={testIdPrefix + "-email"}
           id="email"
           type="email"
           isInvalid={Boolean(errors.email)}
@@ -114,7 +111,6 @@ function ArticleForm({
       <Form.Group className="mb-3">
         <Form.Label htmlFor="dateAdded">Date Added(iso format)</Form.Label>
         <Form.Control
-          data-testid={testIdPrefix + "-dateAdded"}
           id="dateAdded"
           type="datetime-local"
           isInvalid={Boolean(errors.dateAdded)}
@@ -128,9 +124,7 @@ function ArticleForm({
         </Form.Control.Feedback>
       </Form.Group>
 
-      <Button type="submit" data-testid={testIdPrefix + "-submit"}>
-        {buttonLabel}
-      </Button>
+      <Button type="submit">{buttonLabel}</Button>
       <Button
         variant="Secondary"
         onClick={() => navigate(-1)}

--- a/frontend/src/main/components/Articles/ArticleTable.jsx
+++ b/frontend/src/main/components/Articles/ArticleTable.jsx
@@ -1,0 +1,73 @@
+import React from "react";
+import OurTable, { ButtonColumn } from "main/components/OurTable";
+
+import { useBackendMutation } from "main/utils/useBackend";
+import {
+  cellToAxiosParamsDelete,
+  onDeleteSuccess,
+} from "main/utils/articleUtils";
+import { useNavigate } from "react-router";
+import { hasRole } from "main/utils/useCurrentUser";
+
+export default function ArticleTable({
+  articles,
+  currentUser,
+  testIdPrefix = "ArticleTable",
+}) {
+  const navigate = useNavigate();
+
+  const editCallback = (cell) => {
+    navigate(`/articles/edit/${cell.row.original.id}`);
+  };
+
+  // Stryker disable all : hard to test for query caching
+
+  const deleteMutation = useBackendMutation(
+    cellToAxiosParamsDelete,
+    { onSuccess: onDeleteSuccess },
+    ["/api/articles/all"],
+  );
+  // Stryker restore all
+
+  // Stryker disable next-line all : TODO try to make a good test for this
+  const deleteCallback = async (cell) => {
+    deleteMutation.mutate(cell);
+  };
+
+  const columns = [
+    {
+      header: "id",
+      accessorKey: "id", // accessor is the "key" in the data
+    },
+
+    {
+      header: "Title",
+      accessorKey: "title",
+    },
+    {
+      header: "Url",
+      accessorKey: "url",
+    },
+    {
+      header: "Explanation",
+      accessorKey: "explanation",
+    },
+    {
+      header: "Email",
+      accessorKey: "email",
+    },
+    {
+      header: "Date Added(iso format)",
+      accessorKey: "dateAdded",
+    },
+  ];
+
+  if (hasRole(currentUser, "ROLE_ADMIN")) {
+    columns.push(ButtonColumn("Edit", "primary", editCallback, testIdPrefix));
+    columns.push(
+      ButtonColumn("Delete", "danger", deleteCallback, testIdPrefix),
+    );
+  }
+
+  return <OurTable data={articles} columns={columns} testid={testIdPrefix} />;
+}

--- a/frontend/src/main/components/Nav/AppNavbar.jsx
+++ b/frontend/src/main/components/Nav/AppNavbar.jsx
@@ -71,6 +71,9 @@ export default function AppNavbar({
                   <Nav.Link as={Link} to="/placeholder">
                     Placeholder
                   </Nav.Link>
+                  <Nav.Link as={Link} to="/articles">
+                    Articles
+                  </Nav.Link>
                 </>
               ) : (
                 <></>

--- a/frontend/src/main/pages/Articles/ArticlesCreatePage.jsx
+++ b/frontend/src/main/pages/Articles/ArticlesCreatePage.jsx
@@ -1,0 +1,12 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function ArticlesCreatePage() {
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Create page not yet implemented</h1>
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/main/pages/Articles/ArticlesEditPage.jsx
+++ b/frontend/src/main/pages/Articles/ArticlesEditPage.jsx
@@ -1,0 +1,12 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function ArticlesEditPage() {
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Edit page not yet implemented</h1>
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/main/pages/Articles/ArticlesIndexPage.jsx
+++ b/frontend/src/main/pages/Articles/ArticlesIndexPage.jsx
@@ -1,0 +1,18 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function ArticlesIndexPage() {
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Index page not yet implemented</h1>
+        <p>
+          <a href="/articles/create">Create</a>
+        </p>
+        <p>
+          <a href="/articles/edit/1">Edit</a>
+        </p>
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/main/utils/articleUtils.js
+++ b/frontend/src/main/utils/articleUtils.js
@@ -1,0 +1,16 @@
+import { toast } from "react-toastify";
+
+export function onDeleteSuccess(message) {
+  console.log(message);
+  toast(message);
+}
+
+export function cellToAxiosParamsDelete(cell) {
+  return {
+    url: "/api/articles",
+    method: "DELETE",
+    params: {
+      id: cell.row.original.id,
+    },
+  };
+}

--- a/frontend/src/stories/components/Articles/ArticleForm.stories.jsx
+++ b/frontend/src/stories/components/Articles/ArticleForm.stories.jsx
@@ -1,0 +1,33 @@
+import React from "react";
+import ArticleForm from "main/components/Articles/ArticleForm";
+import { articleFixtures } from "fixtures/articleFixtures";
+
+export default {
+  title: "components/Articles/ArticleForm",
+  component: ArticleForm,
+};
+
+const Template = (args) => {
+  return <ArticleForm {...args} />;
+};
+
+export const Create = Template.bind({});
+
+Create.args = {
+  buttonLabel: "Create",
+  submitAction: (data) => {
+    console.log("Submit was clicked with data: ", data);
+    window.alert("Submit was clicked with data: " + JSON.stringify(data));
+  },
+};
+
+export const Update = Template.bind({});
+
+Update.args = {
+  initialContents: articleFixtures.oneArticle,
+  buttonLabel: "Update",
+  submitAction: (data) => {
+    console.log("Submit was clicked with data: ", data);
+    window.alert("Submit was clicked with data: " + JSON.stringify(data));
+  },
+};

--- a/frontend/src/stories/components/Articles/ArticleTable.stories.jsx
+++ b/frontend/src/stories/components/Articles/ArticleTable.stories.jsx
@@ -1,0 +1,45 @@
+import React from "react";
+import ArticleTable from "main/components/Articles/ArticleTable";
+import { articleFixtures } from "fixtures/articleFixtures";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+import { http, HttpResponse } from "msw";
+
+export default {
+  title: "components/Articles/ArticleTable",
+  component: ArticleTable,
+};
+
+const Template = (args) => {
+  return <ArticleTable {...args} />;
+};
+
+export const Empty = Template.bind({});
+
+Empty.args = {
+  articles: [],
+  currentUser: currentUserFixtures.userOnly,
+};
+
+export const ThreeItemsOrdinaryUser = Template.bind({});
+
+ThreeItemsOrdinaryUser.args = {
+  articles: articleFixtures.threeArticles,
+  currentUser: currentUserFixtures.userOnly,
+};
+
+export const ThreeItemsAdminUser = Template.bind({});
+ThreeItemsAdminUser.args = {
+  articles: articleFixtures.threeArticles,
+  currentUser: currentUserFixtures.adminUser,
+};
+
+ThreeItemsAdminUser.parameters = {
+  msw: [
+    http.delete("/api/articles", () => {
+      return HttpResponse.json(
+        { message: "Article deleted successfully" },
+        { status: 200 },
+      );
+    }),
+  ],
+};

--- a/frontend/src/tests/components/Articles/ArticleForm.test.jsx
+++ b/frontend/src/tests/components/Articles/ArticleForm.test.jsx
@@ -1,0 +1,111 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { BrowserRouter as Router } from "react-router";
+
+import ArticleForm from "main/components/Articles/ArticleForm";
+import { articleFixtures } from "fixtures/articleFixtures";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { expect } from "vitest";
+
+const mockedNavigate = vi.fn();
+vi.mock("react-router", async () => {
+  const originalModule = await vi.importActual("react-router");
+  return {
+    ...originalModule,
+    useNavigate: () => mockedNavigate,
+  };
+});
+
+describe("ArticleForm tests", () => {
+  const queryClient = new QueryClient();
+
+  const expectedHeaders = [
+    "Title",
+    "Url",
+    "Explanation",
+    "Email",
+    "Date Added(iso format)",
+  ];
+  const testId = "ArticleForm";
+
+  test("renders correctly with no initialContents", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <ArticleForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText(/Create/)).toBeInTheDocument();
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+  });
+
+  test("renders correctly when passing in initialContents", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <ArticleForm initialContents={articleFixtures.oneArticle} />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText(/Create/)).toBeInTheDocument();
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(await screen.findByTestId(`${testId}-id`)).toBeInTheDocument();
+    expect(screen.getByText(`Id`)).toBeInTheDocument();
+  });
+
+  test("that navigate(-1) is called when Cancel is clicked", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <ArticleForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+    expect(await screen.findByTestId(`${testId}-cancel`)).toBeInTheDocument();
+    const cancelButton = screen.getByTestId(`${testId}-cancel`);
+
+    fireEvent.click(cancelButton);
+
+    await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith(-1));
+  });
+
+  test("that the correct validations are performed", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <ArticleForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText(/Create/)).toBeInTheDocument();
+    const submitButton = screen.getByText(/Create/);
+    fireEvent.click(submitButton);
+
+    await screen.findByText(/Title is required/);
+    expect(screen.getByText(/Url is required/)).toBeInTheDocument();
+    expect(screen.getByText(/Explanation is required/)).toBeInTheDocument();
+    expect(screen.getByText(/Email is required/)).toBeInTheDocument();
+    expect(screen.getByText(/Date Added is required/)).toBeInTheDocument();
+
+    const titleInput = screen.getByTestId(`${testId}-title`);
+    fireEvent.change(titleInput, { target: { value: "a".repeat(256) } });
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Max length 255 characters/)).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/tests/components/Articles/ArticleTable.test.jsx
+++ b/frontend/src/tests/components/Articles/ArticleTable.test.jsx
@@ -1,0 +1,243 @@
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
+import { articleFixtures } from "fixtures/articleFixtures";
+import ArticleTable from "main/components/Articles/ArticleTable";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+const mockedNavigate = vi.fn();
+vi.mock("react-router", async () => {
+  const originalModule = await vi.importActual("react-router");
+  return {
+    ...originalModule,
+    useNavigate: () => mockedNavigate,
+  };
+});
+
+describe("ArticleTable tests", () => {
+  const queryClient = new QueryClient();
+
+  const expectedHeaders = [
+    "id",
+    "Title",
+    "Url",
+    "Explanation",
+    "Email",
+    "Date Added(iso format)",
+  ];
+  const expectedFields = [
+    "id",
+    "title",
+    "url",
+    "explanation",
+    "email",
+    "dateAdded",
+  ];
+  const testId = "ArticleTable";
+
+  test("renders empty table correctly", () => {
+    // arrange
+    const currentUser = currentUserFixtures.adminUser;
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ArticleTable articles={[]} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // assert
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const fieldElement = screen.queryByTestId(
+        `${testId}-cell-row-0-col-${field}`,
+      );
+      expect(fieldElement).not.toBeInTheDocument();
+    });
+  });
+
+  test("Has the expected column headers, content and buttons for admin user", () => {
+    // arrange
+    const currentUser = currentUserFixtures.adminUser;
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ArticleTable
+            articles={articleFixtures.threeArticles}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // assert
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+      "1",
+    );
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-title`),
+    ).toHaveTextContent("Why are there so many daffodils in Jersey?");
+
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
+      "2",
+    );
+    expect(
+      screen.getByTestId(`${testId}-cell-row-1-col-explanation`),
+    ).toHaveTextContent("Firefall video");
+
+    const editButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Edit-button`,
+    );
+    expect(editButton).toBeInTheDocument();
+    expect(editButton).toHaveClass("btn-primary");
+
+    const deleteButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Delete-button`,
+    );
+    expect(deleteButton).toBeInTheDocument();
+    expect(deleteButton).toHaveClass("btn-danger");
+  });
+
+  test("Has the expected column headers, content for ordinary user", () => {
+    // arrange
+    const currentUser = currentUserFixtures.userOnly;
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ArticleTable
+            articles={articleFixtures.threeArticles}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // assert
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+      "1",
+    );
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-title`),
+    ).toHaveTextContent("Why are there so many daffodils in Jersey?");
+
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
+      "2",
+    );
+    expect(
+      screen.getByTestId(`${testId}-cell-row-1-col-explanation`),
+    ).toHaveTextContent("Firefall video");
+
+    expect(screen.queryByText("Delete")).not.toBeInTheDocument();
+    expect(screen.queryByText("Edit")).not.toBeInTheDocument();
+  });
+
+  test("Edit button navigates to the edit page", async () => {
+    // arrange
+    const currentUser = currentUserFixtures.adminUser;
+
+    // act - render the component
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ArticleTable
+            articles={articleFixtures.threeArticles}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // assert - check that the expected content is rendered
+    expect(
+      await screen.findByTestId(`${testId}-cell-row-0-col-id`),
+    ).toHaveTextContent("1");
+
+    const editButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Edit-button`,
+    );
+    expect(editButton).toBeInTheDocument();
+
+    // act - click the edit button
+    fireEvent.click(editButton);
+
+    // assert - check that the navigate function was called with the expected path
+    await waitFor(() =>
+      expect(mockedNavigate).toHaveBeenCalledWith("/articles/edit/1"),
+    );
+  });
+
+  test("Delete button calls delete callback", async () => {
+    // arrange
+    const currentUser = currentUserFixtures.adminUser;
+
+    const axiosMock = new AxiosMockAdapter(axios);
+    axiosMock
+      .onDelete("/api/articles")
+      .reply(200, { message: "Article deleted" });
+
+    // act - render the component
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ArticleTable
+            articles={articleFixtures.threeArticles}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // assert - check that the expected content is rendered
+    expect(
+      await screen.findByTestId(`${testId}-cell-row-0-col-id`),
+    ).toHaveTextContent("1");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-title`),
+    ).toHaveTextContent("Why are there so many daffodils in Jersey?");
+
+    const deleteButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Delete-button`,
+    );
+    expect(deleteButton).toBeInTheDocument();
+
+    // act - click the delete button
+    fireEvent.click(deleteButton);
+
+    // assert - check that the delete endpoint was called
+
+    await waitFor(() => expect(axiosMock.history.delete.length).toBe(1));
+    expect(axiosMock.history.delete[0].params).toEqual({ id: 1 });
+  });
+});

--- a/frontend/src/tests/pages/Articles/ArticlesCreatePage.test.jsx
+++ b/frontend/src/tests/pages/Articles/ArticlesCreatePage.test.jsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import ArticlesCreatePage from "main/pages/Articles/ArticlesCreatePage";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+import { expect } from "vitest";
+
+describe("ArticlesCreatePage tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  const setupUserOnly = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  const queryClient = new QueryClient();
+  test("Renders expected content", async () => {
+    // arrange
+
+    setupUserOnly();
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ArticlesCreatePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // assert
+
+    await screen.findByText("Create page not yet implemented");
+    expect(
+      screen.getByText("Create page not yet implemented"),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/pages/Articles/ArticlesEditPage.test.jsx
+++ b/frontend/src/tests/pages/Articles/ArticlesEditPage.test.jsx
@@ -1,0 +1,47 @@
+import { render, screen } from "@testing-library/react";
+import ArticlesEditPage from "main/pages/Articles/ArticlesEditPage";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+import { expect } from "vitest";
+
+describe("ArticlesEditPage tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  const setupUserOnly = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  const queryClient = new QueryClient();
+  test("Renders expected content", async () => {
+    // arrange
+
+    setupUserOnly();
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ArticlesEditPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // assert
+    await screen.findByText("Edit page not yet implemented");
+    expect(
+      screen.getByText("Edit page not yet implemented"),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/pages/Articles/ArticlesIndexPage.test.jsx
+++ b/frontend/src/tests/pages/Articles/ArticlesIndexPage.test.jsx
@@ -1,0 +1,50 @@
+import { render, screen } from "@testing-library/react";
+import ArticlesIndexPage from "main/pages/Articles/ArticlesIndexPage";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+describe("PlaceholderIndexPage tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  const setupUserOnly = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  const queryClient = new QueryClient();
+  test("Renders expected content", async () => {
+    // arrange
+
+    setupUserOnly();
+
+    // act
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ArticlesIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await screen.findByText("Index page not yet implemented");
+
+    // assert
+    expect(
+      screen.getByText("Index page not yet implemented"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Create")).toBeInTheDocument();
+    expect(screen.getByText("Edit")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/utils/ArticleUtils.test.js
+++ b/frontend/src/tests/utils/ArticleUtils.test.js
@@ -1,0 +1,50 @@
+import {
+  onDeleteSuccess,
+  cellToAxiosParamsDelete,
+} from "main/utils/articleUtils";
+import mockConsole from "tests/testutils/mockConsole";
+
+const mockToast = vi.fn();
+vi.mock("react-toastify", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    toast: vi.fn((x) => mockToast(x)),
+  };
+});
+
+describe("ArticleUtils", () => {
+  describe("onDeleteSuccess", () => {
+    test("It puts the message on console.log and in a toast", () => {
+      // arrange
+      const restoreConsole = mockConsole();
+
+      // act
+      onDeleteSuccess("abc");
+
+      // assert
+      expect(mockToast).toHaveBeenCalledWith("abc");
+      expect(console.log).toHaveBeenCalled();
+      const message = console.log.mock.calls[0][0];
+      expect(message).toMatch("abc");
+
+      restoreConsole();
+    });
+  });
+  describe("cellToAxiosParamsDelete", () => {
+    test("It returns the correct params", () => {
+      // arrange
+      const cell = { row: { original: { id: 17 } } };
+
+      // act
+      const result = cellToAxiosParamsDelete(cell);
+
+      // assert
+      expect(result).toEqual({
+        url: "/api/articles",
+        method: "DELETE",
+        params: { id: 17 },
+      });
+    });
+  });
+});


### PR DESCRIPTION
Closes #51 

Does not depend on any other PR to be merged first.

In this PR, we add placeholder pages for Index, Create and Edit pages for the articles table.

You can see this at the moment on this dokku instance (after you login)

https://team02-dev-prishabobde.dokku-06.cs.ucsb.edu/

Screenshots:
<img width="728" height="236" alt="Screenshot 2026-05-03 at 10 49 10 AM" src="https://github.com/user-attachments/assets/2f1de27d-c941-4851-b445-7f81cf1c4b5a" />

<img width="813" height="261" alt="Screenshot 2026-05-03 at 10 49 19 AM" src="https://github.com/user-attachments/assets/6d572e93-3c97-4fa8-ba24-44b0680c34bb" />

<img width="755" height="230" alt="Screenshot 2026-05-03 at 10 49 32 AM" src="https://github.com/user-attachments/assets/af60bc35-b187-401a-89dc-e16b90550c6e" />

