### PR TITLE
Ev menuitems implement create page

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -76,7 +76,7 @@ function App() {
         <>
           <Route
             exact
-            path="/ucsbdiningcommonsmenuitem"
+            path="/diningcommonsmenuitem"
             element={<UCSBDiningCommonsMenuItemIndexPage />}
           />
         </>
@@ -85,12 +85,12 @@ function App() {
         <>
           <Route
             exact
-            path="/ucsbdiningcommonsmenuitem/edit/:id"
+            path="/diningcommonsmenuitem/edit/:id"
             element={<UCSBDiningCommonsMenuItemEditPage />}
           />
           <Route
             exact
-            path="/ucsbdiningcommonsmenuitem/create"
+            path="/diningcommonsmenuitem/create"
             element={<UCSBDiningCommonsMenuItemCreatePage />}
           />
         </>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -173,29 +173,29 @@ function App() {
           />
         </>
       )}
-        {hasRole(currentUser, "ROLE_USER") && (
-            <>
-                <Route
-                    exact
-                    path="/helprequests"
-                    element={<HelpRequestsIndexPage />}
-                />
-            </>
-        )}
-        {hasRole(currentUser, "ROLE_ADMIN") && (
-            <>
-                <Route
-                    exact
-                    path="/helprequests/edit/:id"
-                    element={<HelpRequestsEditPage />}
-                />
-                <Route
-                    exact
-                    path="/helprequests/create"
-                    element={<HelpRequestsCreatePage />}
-                />
-            </>
-        )}
+      {hasRole(currentUser, "ROLE_USER") && (
+        <>
+          <Route
+            exact
+            path="/helprequests"
+            element={<HelpRequestsIndexPage />}
+          />
+        </>
+      )}
+      {hasRole(currentUser, "ROLE_ADMIN") && (
+        <>
+          <Route
+            exact
+            path="/helprequests/edit/:id"
+            element={<HelpRequestsEditPage />}
+          />
+          <Route
+            exact
+            path="/helprequests/create"
+            element={<HelpRequestsCreatePage />}
+          />
+        </>
+      )}
       {hasRole(currentUser, "ROLE_USER") && (
         <>
           <Route exact path="/placeholder" element={<PlaceholderIndexPage />} />

--- a/frontend/src/main/components/Nav/AppNavbar.jsx
+++ b/frontend/src/main/components/Nav/AppNavbar.jsx
@@ -68,7 +68,7 @@ export default function AppNavbar({
                   <Nav.Link as={Link} to="/ucsbdates">
                     UCSB Dates
                   </Nav.Link>
-                  <Nav.Link as={Link} to="/ucsbdiningcommonsmenuitem">
+                  <Nav.Link as={Link} to="/diningcommonsmenuitem">
                     Menu Items
                   </Nav.Link>
                   <Nav.Link as={Link} to="/placeholder">

--- a/frontend/src/main/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemTable.jsx
+++ b/frontend/src/main/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemTable.jsx
@@ -16,7 +16,7 @@ export default function UCSBDiningCommonsMenuItemTable({
   const navigate = useNavigate();
 
   const editCallback = (cell) => {
-    navigate(`/ucsbdiningcommonsmenuitem/edit/${cell.row.original.id}`);
+    navigate(`/diningcommonsmenuitem/edit/${cell.row.original.id}`);
   };
 
   // Stryker disable all : hard to test for query caching

--- a/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage.jsx
+++ b/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage.jsx
@@ -4,42 +4,47 @@ import { Navigate } from "react-router";
 import { useBackendMutation } from "main/utils/useBackend";
 import { toast } from "react-toastify";
 
-export default function UCSBDiningCommonsMenuItemCreatePage({ storybook = false }) {
+export default function UCSBDiningCommonsMenuItemCreatePage({
+  storybook = false,
+}) {
+  const objectToAxiosParams = (ucsbDiningCommonsMenuItem) => ({
+    url: "/api/ucsbdiningcommonsmenuitem/post",
+    method: "POST",
+    params: {
+      diningCommonsCode: ucsbDiningCommonsMenuItem.diningCommonsCode,
+      name: ucsbDiningCommonsMenuItem.name,
+      station: ucsbDiningCommonsMenuItem.station,
+    },
+  });
 
-    const objectToAxiosParams = (ucsbDiningCommonsMenuItem) => ({
-        url: "/api/ucsbdiningcommonsmenuitem/post",
-        method: "POST",
-        params: {
-            diningCommonsCode: ucsbDiningCommonsMenuItem.diningCommonsCode,
-            name: ucsbDiningCommonsMenuItem.name,
-            station: ucsbDiningCommonsMenuItem.station,
-        },
-    });
-
-    const onSuccess = (ucsbDiningCommonsMenuItem) => {
-        toast(`New UCSBDiningCommonsMenuItem Created - id: ${ucsbDiningCommonsMenuItem.id} name: ${ucsbDiningCommonsMenuItem.name}`);
-    };
-
-    const mutation = useBackendMutation(objectToAxiosParams, { onSuccess },
-        // Stryker disable next-line all : hard to set up test for caching
-        ["/api/ucsbdiningcommonsmenuitem/all"],
+  const onSuccess = (ucsbDiningCommonsMenuItem) => {
+    toast(
+      `New UCSBDiningCommonsMenuItem Created - id: ${ucsbDiningCommonsMenuItem.id} name: ${ucsbDiningCommonsMenuItem.name}`,
     );
+  };
 
-    const { isSuccess } = mutation;
+  const mutation = useBackendMutation(
+    objectToAxiosParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    ["/api/ucsbdiningcommonsmenuitem/all"],
+  );
 
-    const onSubmit = async (data) => {
-        mutation.mutate(data);
-    };
+  const { isSuccess } = mutation;
 
-    if (isSuccess && !storybook) {
-        return <Navigate to="/ucsbdiningcommonsmenuitem" />;
-    }
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  };
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/diningcommonsmenuitem" />;
+  }
 
   return (
     <BasicLayout>
       <div className="pt-2">
         <h1>Create new Dining Commons Menu Item</h1>
-          <UCSBDiningCommonsMenuItemForm submitAction={onSubmit} />
+        <UCSBDiningCommonsMenuItemForm submitAction={onSubmit} />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage.jsx
+++ b/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage.jsx
@@ -1,11 +1,45 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import UCSBDiningCommonsMenuItemForm from "main/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemForm";
+import { Navigate } from "react-router";
+import { useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function UCSBDiningCommonsMenuItemCreatePage() {
-  // Stryker disable all : placeholder for future implementation
+export default function UCSBDiningCommonsMenuItemCreatePage({ storybook = false }) {
+
+    const objectToAxiosParams = (ucsbDiningCommonsMenuItem) => ({
+        url: "/api/ucsbdiningcommonsmenuitem/post",
+        method: "POST",
+        params: {
+            diningCommonsCode: ucsbDiningCommonsMenuItem.diningCommonsCode,
+            name: ucsbDiningCommonsMenuItem.name,
+            station: ucsbDiningCommonsMenuItem.station,
+        },
+    });
+
+    const onSuccess = (ucsbDiningCommonsMenuItem) => {
+        toast(`New UCSBDiningCommonsMenuItem Created - id: ${ucsbDiningCommonsMenuItem.id} name: ${ucsbDiningCommonsMenuItem.name}`);
+    };
+
+    const mutation = useBackendMutation(objectToAxiosParams, { onSuccess },
+        // Stryker disable next-line all : hard to set up test for caching
+        ["/api/ucsbdiningcommonsmenuitem/all"],
+    );
+
+    const { isSuccess } = mutation;
+
+    const onSubmit = async (data) => {
+        mutation.mutate(data);
+    };
+
+    if (isSuccess && !storybook) {
+        return <Navigate to="/ucsbdiningcommonsmenuitem" />;
+    }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Create page not yet implemented</h1>
+        <h1>Create new Dining Commons Menu Item</h1>
+          <UCSBDiningCommonsMenuItemForm submitAction={onSubmit} />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage.jsx
+++ b/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage.jsx
@@ -7,10 +7,10 @@ export default function UCSBDiningCommonsMenuItemIndexPage() {
       <div className="pt-2">
         <h1>Index page not yet implemented</h1>
         <p>
-          <a href="/ucsbdiningcommonsmenuitem/create">Create</a>
+          <a href="/diningcommonsmenuitem/create">Create</a>
         </p>
         <p>
-          <a href="/ucsbdiningcommonsmenuitem/edit/1">Edit</a>
+          <a href="/diningcommonsmenuitem/edit/1">Edit</a>
         </p>
       </div>
     </BasicLayout>

--- a/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage.jsx
+++ b/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage.jsx
@@ -7,10 +7,10 @@ export default function UCSBDiningCommonsMenuItemIndexPage() {
       <div className="pt-2">
         <h1>Index page not yet implemented</h1>
         <p>
-          <a href="/placeholder/create">Create</a>
+          <a href="/ucsbdiningcommonsmenuitem/create">Create</a>
         </p>
         <p>
-          <a href="/placeholder/edit/1">Edit</a>
+          <a href="/ucsbdiningcommonsmenuitem/edit/1">Edit</a>
         </p>
       </div>
     </BasicLayout>

--- a/frontend/src/stories/pages/UCSBDiningCommonsMenuItems/UCSBDiningCommonsMenuItemCreatePage.stories.jsx
+++ b/frontend/src/stories/pages/UCSBDiningCommonsMenuItems/UCSBDiningCommonsMenuItemCreatePage.stories.jsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { http, HttpResponse } from "msw";
+
+import UCSBDiningCommonsMenuItemCreatePage from "main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage.jsx";
+
+export default {
+  title: "pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage",
+  component: UCSBDiningCommonsMenuItemCreatePage,
+};
+
+const Template = () => <UCSBDiningCommonsMenuItemCreatePage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.post("/api/ucsbdiningcommonsmenuitem/post", () => {
+      return HttpResponse.json({}, { status: 200 });
+    }),
+  ],
+};

--- a/frontend/src/tests/components/UCSBDiningCommonsMenuItems/UCSBDiningCommonsMenuItemTable.test.jsx
+++ b/frontend/src/tests/components/UCSBDiningCommonsMenuItems/UCSBDiningCommonsMenuItemTable.test.jsx
@@ -152,7 +152,7 @@ describe("UserTable tests", () => {
 
     await waitFor(() =>
       expect(mockedNavigate).toHaveBeenCalledWith(
-        "/ucsbdiningcommonsmenuitem/edit/1",
+        "/diningcommonsmenuitem/edit/1",
       ),
     );
   });

--- a/frontend/src/tests/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage.test.jsx
+++ b/frontend/src/tests/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, waitFor, fireEvent, screen } from "@testing-library/react";
 import UCSBDiningCommonsMenuItemCreatePage from "main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage.jsx";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router";
@@ -7,12 +7,32 @@ import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
-import { expect } from "vitest";
 
-describe("UCSBDiningCommonsMenuItemPage tests", () => {
+const mockToast = vi.fn();
+vi.mock("react-toastify", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    toast: vi.fn((x) => mockToast(x)),
+  };
+});
+
+const mockNavigate = vi.fn();
+vi.mock("react-router", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    Navigate: vi.fn((x) => {
+      mockNavigate(x);
+      return null;
+    }),
+  };
+});
+
+describe("UCSBDiningCommonsMenuItemCreatePage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
 
-  const setupUserOnly = () => {
+  beforeEach(() => {
     axiosMock.reset();
     axiosMock.resetHistory();
     axiosMock
@@ -21,15 +41,10 @@ describe("UCSBDiningCommonsMenuItemPage tests", () => {
     axiosMock
       .onGet("/api/systemInfo")
       .reply(200, systemInfoFixtures.showingNeither);
-  };
+  });
 
-  const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
-    // arrange
-
-    setupUserOnly();
-
-    // act
+  test("renders without crashing", async () => {
+    const queryClient = new QueryClient();
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
@@ -38,11 +53,68 @@ describe("UCSBDiningCommonsMenuItemPage tests", () => {
       </QueryClientProvider>,
     );
 
-    // assert
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("UCSBDiningCommonsMenuItem-diningCommonsCode"),
+      ).toBeInTheDocument();
+    });
+  });
 
-    await screen.findByText("Create page not yet implemented");
-    expect(
-      screen.getByText("Create page not yet implemented"),
-    ).toBeInTheDocument();
+  test("when you fill in the form and hit submit, it makes a request to the backend", async () => {
+    const queryClient = new QueryClient();
+    const ucsbDiningCommonsMenuItem = {
+      id: 17,
+      diningCommonsCode: "ortega",
+      name: "chicken",
+      station: "Entrees",
+    };
+
+    axiosMock
+      .onPost("/api/ucsbdiningcommonsmenuitem/post")
+      .reply(202, ucsbDiningCommonsMenuItem);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBDiningCommonsMenuItemCreatePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("UCSBDiningCommonsMenuItem-diningCommonsCode"),
+      ).toBeInTheDocument();
+    });
+
+    const diningCommonsCodeField = screen.getByTestId(
+      "UCSBDiningCommonsMenuItem-diningCommonsCode",
+    );
+    const nameField = screen.getByTestId("UCSBDiningCommonsMenuItem-name");
+    const stationField = screen.getByTestId(
+      "UCSBDiningCommonsMenuItem-station",
+    );
+    const submitButton = screen.getByTestId("UCSBDiningCommonsMenuItem-submit");
+
+    fireEvent.change(diningCommonsCodeField, { target: { value: "ortega" } });
+    fireEvent.change(nameField, { target: { value: "chicken" } });
+    fireEvent.change(stationField, { target: { value: "Entrees" } });
+
+    expect(submitButton).toBeInTheDocument();
+
+    fireEvent.click(submitButton);
+
+    await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+    expect(axiosMock.history.post[0].params).toEqual({
+      diningCommonsCode: "ortega",
+      name: "chicken",
+      station: "Entrees",
+    });
+
+    expect(mockToast).toBeCalledWith(
+      "New UCSBDiningCommonsMenuItem Created - id: 17 name: chicken",
+    );
+    expect(mockNavigate).toBeCalledWith({ to: "/diningcommonsmenuitem" });
   });
 });


### PR DESCRIPTION
Closes #7
merge AFTER #83
implements the create page for diningcommonsmenuitem
to test: deploy, navigate to this 
<img width="104" height="44" alt="image" src="https://github.com/user-attachments/assets/96d26f19-ead1-4af2-819a-f16a327b061a" /> , and ensure you can create a new item, which shows up in the swagger database when using get all
ensure the story and tests meet the requirements

[[link to storybook]](https://69f542c1da16dc378603b48d-iptyxghbsb.chromatic.com/?path=/story/pages-ucsbdiningcommonsmenuitem-ucsbdiningcommonsmenuitemcreatepage--default)
<img width="1202" height="476" alt="image" src="https://github.com/user-attachments/assets/79f5aaf2-2828-430e-8581-71a26ecf7bea" />