### PR TITLE
Ev menuitems implement edit page

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -76,7 +76,7 @@ function App() {
         <>
           <Route
             exact
-            path="/ucsbdiningcommonsmenuitem"
+            path="/diningcommonsmenuitem"
             element={<UCSBDiningCommonsMenuItemIndexPage />}
           />
         </>
@@ -85,12 +85,12 @@ function App() {
         <>
           <Route
             exact
-            path="/ucsbdiningcommonsmenuitem/edit/:id"
+            path="/diningcommonsmenuitem/edit/:id"
             element={<UCSBDiningCommonsMenuItemEditPage />}
           />
           <Route
             exact
-            path="/ucsbdiningcommonsmenuitem/create"
+            path="/diningcommonsmenuitem/create"
             element={<UCSBDiningCommonsMenuItemCreatePage />}
           />
         </>

--- a/frontend/src/main/components/Nav/AppNavbar.jsx
+++ b/frontend/src/main/components/Nav/AppNavbar.jsx
@@ -68,7 +68,7 @@ export default function AppNavbar({
                   <Nav.Link as={Link} to="/ucsbdates">
                     UCSB Dates
                   </Nav.Link>
-                  <Nav.Link as={Link} to="/ucsbdiningcommonsmenuitem">
+                  <Nav.Link as={Link} to="/diningcommonsmenuitem">
                     Menu Items
                   </Nav.Link>
                   <Nav.Link as={Link} to="/placeholder">

--- a/frontend/src/main/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemTable.jsx
+++ b/frontend/src/main/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemTable.jsx
@@ -16,7 +16,7 @@ export default function UCSBDiningCommonsMenuItemTable({
   const navigate = useNavigate();
 
   const editCallback = (cell) => {
-    navigate(`/ucsbdiningcommonsmenuitem/edit/${cell.row.original.id}`);
+    navigate(`/diningcommonsmenuitem/edit/${cell.row.original.id}`);
   };
 
   // Stryker disable all : hard to test for query caching

--- a/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage.jsx
+++ b/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage.jsx
@@ -4,42 +4,47 @@ import { Navigate } from "react-router";
 import { useBackendMutation } from "main/utils/useBackend";
 import { toast } from "react-toastify";
 
-export default function UCSBDiningCommonsMenuItemCreatePage({ storybook = false }) {
+export default function UCSBDiningCommonsMenuItemCreatePage({
+  storybook = false,
+}) {
+  const objectToAxiosParams = (ucsbDiningCommonsMenuItem) => ({
+    url: "/api/ucsbdiningcommonsmenuitem/post",
+    method: "POST",
+    params: {
+      diningCommonsCode: ucsbDiningCommonsMenuItem.diningCommonsCode,
+      name: ucsbDiningCommonsMenuItem.name,
+      station: ucsbDiningCommonsMenuItem.station,
+    },
+  });
 
-    const objectToAxiosParams = (ucsbDiningCommonsMenuItem) => ({
-        url: "/api/ucsbdiningcommonsmenuitem/post",
-        method: "POST",
-        params: {
-            diningCommonsCode: ucsbDiningCommonsMenuItem.diningCommonsCode,
-            name: ucsbDiningCommonsMenuItem.name,
-            station: ucsbDiningCommonsMenuItem.station,
-        },
-    });
-
-    const onSuccess = (ucsbDiningCommonsMenuItem) => {
-        toast(`New UCSBDiningCommonsMenuItem Created - id: ${ucsbDiningCommonsMenuItem.id} name: ${ucsbDiningCommonsMenuItem.name}`);
-    };
-
-    const mutation = useBackendMutation(objectToAxiosParams, { onSuccess },
-        // Stryker disable next-line all : hard to set up test for caching
-        ["/api/ucsbdiningcommonsmenuitem/all"],
+  const onSuccess = (ucsbDiningCommonsMenuItem) => {
+    toast(
+      `New UCSBDiningCommonsMenuItem Created - id: ${ucsbDiningCommonsMenuItem.id} name: ${ucsbDiningCommonsMenuItem.name}`,
     );
+  };
 
-    const { isSuccess } = mutation;
+  const mutation = useBackendMutation(
+    objectToAxiosParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    ["/api/ucsbdiningcommonsmenuitem/all"],
+  );
 
-    const onSubmit = async (data) => {
-        mutation.mutate(data);
-    };
+  const { isSuccess } = mutation;
 
-    if (isSuccess && !storybook) {
-        return <Navigate to="/ucsbdiningcommonsmenuitem" />;
-    }
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  };
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/diningcommonsmenuitem" />;
+  }
 
   return (
     <BasicLayout>
       <div className="pt-2">
         <h1>Create new Dining Commons Menu Item</h1>
-          <UCSBDiningCommonsMenuItemForm submitAction={onSubmit} />
+        <UCSBDiningCommonsMenuItemForm submitAction={onSubmit} />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage.jsx
+++ b/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage.jsx
@@ -1,11 +1,45 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import UCSBDiningCommonsMenuItemForm from "main/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemForm";
+import { Navigate } from "react-router";
+import { useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function UCSBDiningCommonsMenuItemCreatePage() {
-  // Stryker disable all : placeholder for future implementation
+export default function UCSBDiningCommonsMenuItemCreatePage({ storybook = false }) {
+
+    const objectToAxiosParams = (ucsbDiningCommonsMenuItem) => ({
+        url: "/api/ucsbdiningcommonsmenuitem/post",
+        method: "POST",
+        params: {
+            diningCommonsCode: ucsbDiningCommonsMenuItem.diningCommonsCode,
+            name: ucsbDiningCommonsMenuItem.name,
+            station: ucsbDiningCommonsMenuItem.station,
+        },
+    });
+
+    const onSuccess = (ucsbDiningCommonsMenuItem) => {
+        toast(`New UCSBDiningCommonsMenuItem Created - id: ${ucsbDiningCommonsMenuItem.id} name: ${ucsbDiningCommonsMenuItem.name}`);
+    };
+
+    const mutation = useBackendMutation(objectToAxiosParams, { onSuccess },
+        // Stryker disable next-line all : hard to set up test for caching
+        ["/api/ucsbdiningcommonsmenuitem/all"],
+    );
+
+    const { isSuccess } = mutation;
+
+    const onSubmit = async (data) => {
+        mutation.mutate(data);
+    };
+
+    if (isSuccess && !storybook) {
+        return <Navigate to="/ucsbdiningcommonsmenuitem" />;
+    }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Create page not yet implemented</h1>
+        <h1>Create new Dining Commons Menu Item</h1>
+          <UCSBDiningCommonsMenuItemForm submitAction={onSubmit} />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage.jsx
+++ b/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage.jsx
@@ -1,11 +1,75 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { useParams } from "react-router";
+import UCSBDiningCommonsMenuItemForm from "main/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemForm";
+import { Navigate } from "react-router";
+import { useBackend, useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function UCSBDiningCommonsMenuItemEditPage() {
-  // Stryker disable all : placeholder for future implementation
+export default function UCSBDiningCommonsMenuItemEditPage({ storybook = false, }) {
+  let { id } = useParams();
+
+  const {
+    data: ucsbDiningCommonsMenuItem,
+    _error,
+    _status,
+  } = useBackend(
+    // Stryker disable next-line all : don't test internal caching of React Query
+    [`/api/ucsbdiningcommonsmenuitem?id=${id}`],
+    {
+      // Stryker disable next-line all : GET is the default, so changing this to "" doesn't introduce a bug
+      method: "GET",
+      url: `/api/ucsbdiningcommonsmenuitem`,
+      params: {
+        id,
+      },
+    },
+  );
+
+  const objectToAxiosPutParams = (ucsbDiningCommonsMenuItem) => ({
+    url: "/api/ucsbdiningcommonsmenuitem",
+    method: "PUT",
+    params: {
+      id: ucsbDiningCommonsMenuItem.id,
+    },
+    data: {
+      diningCommonsCode: ucsbDiningCommonsMenuItem.diningCommonsCode,
+      name: ucsbDiningCommonsMenuItem.name,
+      station: ucsbDiningCommonsMenuItem.station,
+    },
+  });
+
+  const onSuccess = (ucsbDiningCommonsMenuItem) => {
+    toast(`UCSBDiningCommonsMenuItem Updated - id: ${ucsbDiningCommonsMenuItem.id} name: ${ucsbDiningCommonsMenuItem.name}`,);
+  };
+
+  const mutation = useBackendMutation(
+    objectToAxiosPutParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    [`/api/ucsbdiningcommonsmenuitem?id=${id}`],
+  );
+
+  const { isSuccess } = mutation;
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  };
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/diningcommonsmenuitem" />;
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Edit page not yet implemented</h1>
+        <h1>Edit UCSBDiningCommonsMenuItem</h1>
+        {ucsbDiningCommonsMenuItem && (
+          <UCSBDiningCommonsMenuItemForm
+            initialContents={ucsbDiningCommonsMenuItem}
+            submitAction={onSubmit}
+            buttonLabel="Update"
+          />
+        )}
       </div>
     </BasicLayout>
   );

--- a/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage.jsx
+++ b/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage.jsx
@@ -5,7 +5,9 @@ import { Navigate } from "react-router";
 import { useBackend, useBackendMutation } from "main/utils/useBackend";
 import { toast } from "react-toastify";
 
-export default function UCSBDiningCommonsMenuItemEditPage({ storybook = false, }) {
+export default function UCSBDiningCommonsMenuItemEditPage({
+  storybook = false,
+}) {
   let { id } = useParams();
 
   const {
@@ -39,7 +41,9 @@ export default function UCSBDiningCommonsMenuItemEditPage({ storybook = false, }
   });
 
   const onSuccess = (ucsbDiningCommonsMenuItem) => {
-    toast(`UCSBDiningCommonsMenuItem Updated - id: ${ucsbDiningCommonsMenuItem.id} name: ${ucsbDiningCommonsMenuItem.name}`,);
+    toast(
+      `UCSBDiningCommonsMenuItem Updated - id: ${ucsbDiningCommonsMenuItem.id} name: ${ucsbDiningCommonsMenuItem.name}`,
+    );
   };
 
   const mutation = useBackendMutation(

--- a/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage.jsx
+++ b/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage.jsx
@@ -7,10 +7,10 @@ export default function UCSBDiningCommonsMenuItemIndexPage() {
       <div className="pt-2">
         <h1>Index page not yet implemented</h1>
         <p>
-          <a href="/ucsbdiningcommonsmenuitem/create">Create</a>
+          <a href="/diningcommonsmenuitem/create">Create</a>
         </p>
         <p>
-          <a href="/ucsbdiningcommonsmenuitem/edit/1">Edit</a>
+          <a href="/diningcommonsmenuitem/edit/1">Edit</a>
         </p>
       </div>
     </BasicLayout>

--- a/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage.jsx
+++ b/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage.jsx
@@ -7,10 +7,10 @@ export default function UCSBDiningCommonsMenuItemIndexPage() {
       <div className="pt-2">
         <h1>Index page not yet implemented</h1>
         <p>
-          <a href="/placeholder/create">Create</a>
+          <a href="/ucsbdiningcommonsmenuitem/create">Create</a>
         </p>
         <p>
-          <a href="/placeholder/edit/1">Edit</a>
+          <a href="/ucsbdiningcommonsmenuitem/edit/1">Edit</a>
         </p>
       </div>
     </BasicLayout>

--- a/frontend/src/stories/pages/UCSBDiningCommonsMenuItems/UCSBDiningCommonsMenuItemCreatePage.stories.jsx
+++ b/frontend/src/stories/pages/UCSBDiningCommonsMenuItems/UCSBDiningCommonsMenuItemCreatePage.stories.jsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { http, HttpResponse } from "msw";
+
+import UCSBDiningCommonsMenuItemCreatePage from "main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage.jsx";
+
+export default {
+  title: "pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage",
+  component: UCSBDiningCommonsMenuItemCreatePage,
+};
+
+const Template = () => <UCSBDiningCommonsMenuItemCreatePage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.post("/api/ucsbdiningcommonsmenuitem/post", () => {
+      return HttpResponse.json({}, { status: 200 });
+    }),
+  ],
+};

--- a/frontend/src/stories/pages/UCSBDiningCommonsMenuItems/UCSBDiningCommonsMenuItemEditPage.stories.jsx
+++ b/frontend/src/stories/pages/UCSBDiningCommonsMenuItems/UCSBDiningCommonsMenuItemEditPage.stories.jsx
@@ -27,9 +27,12 @@ Default.parameters = {
       });
     }),
     http.get("/api/ucsbdiningcommonsmenuitem", () => {
-      return HttpResponse.json(ucsbDiningCommonsMenuItemFixtures.threeMenuItems[0], {
-        status: 200,
-      });
+      return HttpResponse.json(
+        ucsbDiningCommonsMenuItemFixtures.threeMenuItems[0],
+        {
+          status: 200,
+        },
+      );
     }),
     http.put("/api/ucsbdiningcommonsmenuitem", () => {
       return HttpResponse.json({}, { status: 200 });

--- a/frontend/src/stories/pages/UCSBDiningCommonsMenuItems/UCSBDiningCommonsMenuItemEditPage.stories.jsx
+++ b/frontend/src/stories/pages/UCSBDiningCommonsMenuItems/UCSBDiningCommonsMenuItemEditPage.stories.jsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { ucsbDiningCommonsMenuItemFixtures } from "fixtures/ucsbDiningCommonsMenuItemFixtures";
+import { http, HttpResponse } from "msw";
+
+import UCSBDiningCommonsMenuItemEditPage from "main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage";
+
+export default {
+  title: "pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage",
+  component: UCSBDiningCommonsMenuItemEditPage,
+};
+
+const Template = () => <UCSBDiningCommonsMenuItemEditPage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.get("/api/ucsbdiningcommonsmenuitem", () => {
+      return HttpResponse.json(ucsbDiningCommonsMenuItemFixtures.threeMenuItems[0], {
+        status: 200,
+      });
+    }),
+    http.put("/api/ucsbdiningcommonsmenuitem", () => {
+      return HttpResponse.json({}, { status: 200 });
+    }),
+  ],
+};

--- a/frontend/src/tests/components/UCSBDiningCommonsMenuItems/UCSBDiningCommonsMenuItemTable.test.jsx
+++ b/frontend/src/tests/components/UCSBDiningCommonsMenuItems/UCSBDiningCommonsMenuItemTable.test.jsx
@@ -152,7 +152,7 @@ describe("UserTable tests", () => {
 
     await waitFor(() =>
       expect(mockedNavigate).toHaveBeenCalledWith(
-        "/ucsbdiningcommonsmenuitem/edit/1",
+        "/diningcommonsmenuitem/edit/1",
       ),
     );
   });

--- a/frontend/src/tests/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage.test.jsx
+++ b/frontend/src/tests/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, waitFor, fireEvent, screen } from "@testing-library/react";
 import UCSBDiningCommonsMenuItemCreatePage from "main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage.jsx";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router";
@@ -7,12 +7,32 @@ import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
-import { expect } from "vitest";
 
-describe("UCSBDiningCommonsMenuItemPage tests", () => {
+const mockToast = vi.fn();
+vi.mock("react-toastify", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    toast: vi.fn((x) => mockToast(x)),
+  };
+});
+
+const mockNavigate = vi.fn();
+vi.mock("react-router", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    Navigate: vi.fn((x) => {
+      mockNavigate(x);
+      return null;
+    }),
+  };
+});
+
+describe("UCSBDiningCommonsMenuItemCreatePage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
 
-  const setupUserOnly = () => {
+  beforeEach(() => {
     axiosMock.reset();
     axiosMock.resetHistory();
     axiosMock
@@ -21,15 +41,10 @@ describe("UCSBDiningCommonsMenuItemPage tests", () => {
     axiosMock
       .onGet("/api/systemInfo")
       .reply(200, systemInfoFixtures.showingNeither);
-  };
+  });
 
-  const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
-    // arrange
-
-    setupUserOnly();
-
-    // act
+  test("renders without crashing", async () => {
+    const queryClient = new QueryClient();
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
@@ -38,11 +53,68 @@ describe("UCSBDiningCommonsMenuItemPage tests", () => {
       </QueryClientProvider>,
     );
 
-    // assert
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("UCSBDiningCommonsMenuItem-diningCommonsCode"),
+      ).toBeInTheDocument();
+    });
+  });
 
-    await screen.findByText("Create page not yet implemented");
-    expect(
-      screen.getByText("Create page not yet implemented"),
-    ).toBeInTheDocument();
+  test("when you fill in the form and hit submit, it makes a request to the backend", async () => {
+    const queryClient = new QueryClient();
+    const ucsbDiningCommonsMenuItem = {
+      id: 17,
+      diningCommonsCode: "ortega",
+      name: "chicken",
+      station: "Entrees",
+    };
+
+    axiosMock
+      .onPost("/api/ucsbdiningcommonsmenuitem/post")
+      .reply(202, ucsbDiningCommonsMenuItem);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBDiningCommonsMenuItemCreatePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("UCSBDiningCommonsMenuItem-diningCommonsCode"),
+      ).toBeInTheDocument();
+    });
+
+    const diningCommonsCodeField = screen.getByTestId(
+      "UCSBDiningCommonsMenuItem-diningCommonsCode",
+    );
+    const nameField = screen.getByTestId("UCSBDiningCommonsMenuItem-name");
+    const stationField = screen.getByTestId(
+      "UCSBDiningCommonsMenuItem-station",
+    );
+    const submitButton = screen.getByTestId("UCSBDiningCommonsMenuItem-submit");
+
+    fireEvent.change(diningCommonsCodeField, { target: { value: "ortega" } });
+    fireEvent.change(nameField, { target: { value: "chicken" } });
+    fireEvent.change(stationField, { target: { value: "Entrees" } });
+
+    expect(submitButton).toBeInTheDocument();
+
+    fireEvent.click(submitButton);
+
+    await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+    expect(axiosMock.history.post[0].params).toEqual({
+      diningCommonsCode: "ortega",
+      name: "chicken",
+      station: "Entrees",
+    });
+
+    expect(mockToast).toBeCalledWith(
+      "New UCSBDiningCommonsMenuItem Created - id: 17 name: chicken",
+    );
+    expect(mockNavigate).toBeCalledWith({ to: "/diningcommonsmenuitem" });
   });
 });

--- a/frontend/src/tests/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage.test.jsx
+++ b/frontend/src/tests/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage.test.jsx
@@ -1,47 +1,210 @@
-import { render, screen } from "@testing-library/react";
-import UCSBDiningCommonsMenuItemEditPage from "main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage.jsx";
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router";
+import UCSBDiningCommonsMenuItemEditPage from "main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
-import { expect } from "vitest";
 
-describe("UCSBDiningCommonsMenuItemEditPage tests", () => {
-  const axiosMock = new AxiosMockAdapter(axios);
+import mockConsole from "tests/testutils/mockConsole";
+import { beforeEach, afterEach } from "vitest";
 
-  const setupUserOnly = () => {
-    axiosMock.reset();
-    axiosMock.resetHistory();
-    axiosMock
-      .onGet("/api/currentUser")
-      .reply(200, apiCurrentUserFixtures.userOnly);
-    axiosMock
-      .onGet("/api/systemInfo")
-      .reply(200, systemInfoFixtures.showingNeither);
+const mockToast = vi.fn();
+vi.mock("react-toastify", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    toast: vi.fn((x) => mockToast(x)),
   };
+});
 
-  const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
-    // arrange
+const mockNavigate = vi.fn();
+vi.mock("react-router", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    useParams: vi.fn(() => ({
+      id: 17,
+    })),
+    Navigate: vi.fn((x) => {
+      mockNavigate(x);
+      return null;
+    }),
+  };
+});
 
-    setupUserOnly();
+let axiosMock;
+describe("UCSBDiningCommonsMenuItemEditPage tests", () => {
+  describe("when the backend doesn't return data", () => {
+    beforeEach(() => {
+      axiosMock = new AxiosMockAdapter(axios);
+      axiosMock
+        .onGet("/api/currentUser")
+        .reply(200, apiCurrentUserFixtures.userOnly);
+      axiosMock
+        .onGet("/api/systemInfo")
+        .reply(200, systemInfoFixtures.showingNeither);
+      axiosMock
+        .onGet("/api/ucsbdiningcommonsmenuitem", { params: { id: 17 } })
+        .timeout();
+    });
 
-    // act
-    render(
-      <QueryClientProvider client={queryClient}>
-        <MemoryRouter>
-          <UCSBDiningCommonsMenuItemEditPage />
-        </MemoryRouter>
-      </QueryClientProvider>,
-    );
+    afterEach(() => {
+      mockToast.mockClear();
+      mockNavigate.mockClear();
+      axiosMock.restore();
+      axiosMock.resetHistory();
+    });
 
-    // assert
-    await screen.findByText("Edit page not yet implemented");
-    expect(
-      screen.getByText("Edit page not yet implemented"),
-    ).toBeInTheDocument();
+    const queryClient = new QueryClient();
+    test("renders header but form is not present", async () => {
+      const restoreConsole = mockConsole();
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <UCSBDiningCommonsMenuItemEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      await screen.findByText(/Welcome/);
+      await screen.findByText("Edit UCSBDiningCommonsMenuItem");
+      expect(
+        screen.queryByTestId("UCSBDiningCommonsMenuItem-diningCommonsCode"),
+      ).not.toBeInTheDocument();
+      restoreConsole();
+    });
+  });
+
+  describe("tests where backend is working normally", () => {
+    beforeEach(() => {
+      axiosMock = new AxiosMockAdapter(axios);
+      axiosMock.reset();
+      axiosMock.resetHistory();
+      axiosMock
+        .onGet("/api/currentUser")
+        .reply(200, apiCurrentUserFixtures.userOnly);
+      axiosMock
+        .onGet("/api/systemInfo")
+        .reply(200, systemInfoFixtures.showingNeither);
+      axiosMock
+        .onGet("/api/ucsbdiningcommonsmenuitem", { params: { id: 17 } })
+        .reply(200, {
+          id: 17,
+          diningCommonsCode: "ortega",
+          name: "chicken",
+          station: "entrees",
+        });
+      axiosMock.onPut("/api/ucsbdiningcommonsmenuitem").reply(200, {
+        id: "17",
+        diningCommonsCode: "portola",
+        name: "pizza",
+        station: "Entrees",
+      });
+    });
+
+    afterEach(() => {
+      mockToast.mockClear();
+      mockNavigate.mockClear();
+      axiosMock.restore();
+      axiosMock.resetHistory();
+    });
+
+    const queryClient = new QueryClient();
+    test("renders without crashing", async () => {
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <UCSBDiningCommonsMenuItemEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+      await screen.findByText(/Welcome/);
+      await screen.findByTestId("UCSBDiningCommonsMenuItem-diningCommonsCode");
+      expect(
+        screen.getByTestId("UCSBDiningCommonsMenuItem-diningCommonsCode"),
+      ).toBeInTheDocument();
+    });
+
+    test("Is populated with the data provided", async () => {
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <UCSBDiningCommonsMenuItemEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      await screen.findByTestId("UCSBDiningCommonsMenuItem-diningCommonsCode");
+
+      const idField = screen.getByTestId("UCSBDiningCommonsMenuItem-id");
+      const diningCommonsCodeField = screen.getByTestId(
+        "UCSBDiningCommonsMenuItem-diningCommonsCode",
+      );
+      const nameField = screen.getByTestId("UCSBDiningCommonsMenuItem-name");
+      const stationField = screen.getByTestId(
+        "UCSBDiningCommonsMenuItem-station",
+      );
+      const submitButton = screen.getByTestId("UCSBDiningCommonsMenuItem-submit");
+
+      expect(idField).toHaveValue("17");
+      expect(diningCommonsCodeField).toHaveValue("ortega");
+      expect(nameField).toHaveValue("chicken");
+      expect(stationField).toHaveValue("entrees");
+      expect(submitButton).toBeInTheDocument();
+    });
+
+    test("Changes when you click Update", async () => {
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <UCSBDiningCommonsMenuItemEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      await screen.findByTestId("UCSBDiningCommonsMenuItem-diningCommonsCode");
+
+      const idField = screen.getByTestId("UCSBDiningCommonsMenuItem-id");
+      const diningCommonsCodeField = screen.getByTestId(
+        "UCSBDiningCommonsMenuItem-diningCommonsCode",
+      );
+      const nameField = screen.getByTestId("UCSBDiningCommonsMenuItem-name");
+      const stationField = screen.getByTestId(
+        "UCSBDiningCommonsMenuItem-station",
+      );
+      const submitButton = screen.getByTestId("UCSBDiningCommonsMenuItem-submit");
+
+      expect(idField).toHaveValue("17");
+      expect(diningCommonsCodeField).toHaveValue("ortega");
+      expect(nameField).toHaveValue("chicken");
+      expect(stationField).toHaveValue("entrees");
+      expect(submitButton).toBeInTheDocument();
+
+      fireEvent.change(diningCommonsCodeField, { target: { value: "portola" } });
+      fireEvent.change(nameField, { target: { value: "pizza" } });
+      fireEvent.change(stationField, { target: { value: "Entrees" } });
+
+      fireEvent.click(submitButton);
+
+      await waitFor(() => expect(mockToast).toBeCalled());
+      expect(mockToast).toBeCalledWith(
+        "UCSBDiningCommonsMenuItem Updated - id: 17 name: pizza",
+      );
+      expect(mockNavigate).toBeCalledWith({ to: "/diningcommonsmenuitem" });
+
+      expect(axiosMock.history.put.length).toBe(1);
+      expect(axiosMock.history.put[0].params).toEqual({ id: 17 });
+      expect(axiosMock.history.put[0].data).toBe(
+        JSON.stringify({
+          diningCommonsCode: "portola",
+          name: "pizza",
+          station: "Entrees",
+        }),
+      );
+    });
   });
 });

--- a/frontend/src/tests/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage.test.jsx
+++ b/frontend/src/tests/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage.test.jsx
@@ -148,7 +148,9 @@ describe("UCSBDiningCommonsMenuItemEditPage tests", () => {
       const stationField = screen.getByTestId(
         "UCSBDiningCommonsMenuItem-station",
       );
-      const submitButton = screen.getByTestId("UCSBDiningCommonsMenuItem-submit");
+      const submitButton = screen.getByTestId(
+        "UCSBDiningCommonsMenuItem-submit",
+      );
 
       expect(idField).toHaveValue("17");
       expect(diningCommonsCodeField).toHaveValue("ortega");
@@ -176,7 +178,9 @@ describe("UCSBDiningCommonsMenuItemEditPage tests", () => {
       const stationField = screen.getByTestId(
         "UCSBDiningCommonsMenuItem-station",
       );
-      const submitButton = screen.getByTestId("UCSBDiningCommonsMenuItem-submit");
+      const submitButton = screen.getByTestId(
+        "UCSBDiningCommonsMenuItem-submit",
+      );
 
       expect(idField).toHaveValue("17");
       expect(diningCommonsCodeField).toHaveValue("ortega");
@@ -184,7 +188,9 @@ describe("UCSBDiningCommonsMenuItemEditPage tests", () => {
       expect(stationField).toHaveValue("entrees");
       expect(submitButton).toBeInTheDocument();
 
-      fireEvent.change(diningCommonsCodeField, { target: { value: "portola" } });
+      fireEvent.change(diningCommonsCodeField, {
+        target: { value: "portola" },
+      });
       fireEvent.change(nameField, { target: { value: "pizza" } });
       fireEvent.change(stationField, { target: { value: "Entrees" } });
 


### PR DESCRIPTION
Closes #9
merge AFTER #92
implements the edit page for diningcommonsmenuitem
to test: deploy, navigate to this 
<img width="104" height="44" alt="image" src="https://github.com/user-attachments/assets/96d26f19-ead1-4af2-819a-f16a327b061a" /> , create a new item, edit the item, and ensure the edits show in swagger when using get all
ensure the story and tests meet all requirements

[[link to storybook]](https://69f542c1da16dc378603b48d-voivmswezf.chromatic.com/?path=/story/pages-ucsbdiningcommonsmenuitem-ucsbdiningcommonsmenuitemeditpage--default)
<img width="1203" height="425" alt="image" src="https://github.com/user-attachments/assets/5b9628d3-2c80-4d65-8c3d-e04cbe8a1f70" />
