### PR TITLE
Pb create article page

### DIFF
--- a/frontend/src/main/components/Articles/ArticleForm.jsx
+++ b/frontend/src/main/components/Articles/ArticleForm.jsx
@@ -28,7 +28,7 @@ function ArticleForm({
   // Stryker restore Regex
 
   return (
-    <Form onSubmit={handleSubmit(submitAction)}>
+    <Form noValidate onSubmit={handleSubmit(submitAction)}>
       {initialContents && (
         <Form.Group className="mb-3">
           <Form.Label htmlFor="id">Id</Form.Label>

--- a/frontend/src/main/components/Articles/ArticleForm.jsx
+++ b/frontend/src/main/components/Articles/ArticleForm.jsx
@@ -97,7 +97,7 @@ function ArticleForm({
         <Form.Label htmlFor="email">Email</Form.Label>
         <Form.Control
           id="email"
-          type="email"
+          type="text"
           isInvalid={Boolean(errors.email)}
           {...register("email", {
             required: "Email is required.",

--- a/frontend/src/main/pages/Articles/ArticlesCreatePage.jsx
+++ b/frontend/src/main/pages/Articles/ArticlesCreatePage.jsx
@@ -18,9 +18,7 @@ export default function ArticlesCreatePage({ storybook = false }) {
   });
 
   const onSuccess = (article) => {
-    toast(
-      `New article Created - id: ${article.id} title: ${article.title}`,
-    );
+    toast(`New article Created - id: ${article.id} title: ${article.title}`);
   };
 
   const mutation = useBackendMutation(

--- a/frontend/src/main/pages/Articles/ArticlesCreatePage.jsx
+++ b/frontend/src/main/pages/Articles/ArticlesCreatePage.jsx
@@ -1,11 +1,50 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import ArticleForm from "main/components/Articles/ArticleForm";
+import { Navigate } from "react-router";
+import { useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function ArticlesCreatePage() {
-  // Stryker disable all : placeholder for future implementation
+export default function ArticlesCreatePage({ storybook = false }) {
+  const objectToAxiosParams = (article) => ({
+    url: "/api/articles/post",
+    method: "POST",
+    params: {
+      title: article.title,
+      url: article.url,
+      email: article.email,
+      explanation: article.explanation,
+      dateAdded: article.dateAdded,
+    },
+  });
+
+  const onSuccess = (article) => {
+    toast(
+      `New article Created - id: ${article.id} title: ${article.title}`,
+    );
+  };
+
+  const mutation = useBackendMutation(
+    objectToAxiosParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    ["/api/articles/all"], // mutation makes this key stale so that pages relying on it reload
+  );
+
+  const { isSuccess } = mutation;
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  };
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/articles" />;
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Create page not yet implemented</h1>
+        <h1>Create New Article</h1>
+        <ArticleForm submitAction={onSubmit} />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/stories/pages/Articles/ArticlesCreatePage.stories.jsx
+++ b/frontend/src/stories/pages/Articles/ArticlesCreatePage.stories.jsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { http, HttpResponse } from "msw";
+
+import ArticleCreatePage from "main/pages/Articles/ArticlesCreatePage";
+
+import { articleFixtures } from "fixtures/articleFixtures";
+
+export default {
+  title: "pages/Articles/ArticleCreatePage",
+  component: ArticleCreatePage,
+};
+
+const Template = () => <ArticleCreatePage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.post("/api/articles/post", () => {
+      return HttpResponse.json(articleFixtures.oneArticle, { status: 200 });
+    }),
+  ],
+};

--- a/frontend/src/tests/pages/Articles/ArticlesCreatePage.test.jsx
+++ b/frontend/src/tests/pages/Articles/ArticlesCreatePage.test.jsx
@@ -1,18 +1,40 @@
-import { render, screen } from "@testing-library/react";
-import ArticlesCreatePage from "main/pages/Articles/ArticlesCreatePage";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import ArticleCreatePage from "main/pages/Articles/ArticlesCreatePage";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
-import { expect } from "vitest";
 
-describe("ArticlesCreatePage tests", () => {
+const mockToast = vi.fn();
+vi.mock("react-toastify", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    toast: vi.fn((x) => mockToast(x)),
+  };
+});
+
+const mockNavigate = vi.fn();
+vi.mock("react-router", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    Navigate: vi.fn((x) => {
+      mockNavigate(x);
+      return null;
+    }),
+  };
+});
+
+describe("ArticleCreatePage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
 
-  const setupUserOnly = () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
     axiosMock.reset();
     axiosMock.resetHistory();
     axiosMock
@@ -21,28 +43,103 @@ describe("ArticlesCreatePage tests", () => {
     axiosMock
       .onGet("/api/systemInfo")
       .reply(200, systemInfoFixtures.showingNeither);
-  };
+  });
 
   const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
-    // arrange
-
-    setupUserOnly();
-
-    // act
+  test("renders without crashing", async () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <ArticlesCreatePage />
+          <ArticleCreatePage />
         </MemoryRouter>
       </QueryClientProvider>,
     );
 
-    // assert
+    await waitFor(() => {
+      expect(screen.getByLabelText("Title")).toBeInTheDocument();
+    });
+  });
 
-    await screen.findByText("Create page not yet implemented");
-    expect(
-      screen.getByText("Create page not yet implemented"),
-    ).toBeInTheDocument();
+
+  test("on submit, makes request to backend, and redirects to /articles", async () => {
+    const queryClient = new QueryClient();
+    const article = {
+      id: 7,
+      title: "Why are there so many daffodils in Jersey?",
+      url: "https://www.bbc.com/news/articles/cx2l20rwxgxo",
+      explanation: "Explaining the daffodil bloom",
+      email: "prishabobde@gmail.com",
+      dateAdded: "2024-12-12T05:06:05",
+    };
+
+    axiosMock.onPost("/api/articles/post").reply(202, article);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ArticleCreatePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Title")).toBeInTheDocument();
+    });
+
+    const titleInput = screen.getByLabelText("Title");
+    expect(titleInput).toBeInTheDocument();
+
+    const urlInput = screen.getByLabelText("Url");
+    expect(urlInput).toBeInTheDocument();
+
+    const emailInput = screen.getByLabelText("Email");
+    expect(emailInput).toBeInTheDocument();
+
+    const explanationInput = screen.getByLabelText("Explanation");
+    expect(explanationInput).toBeInTheDocument();
+
+    const dateAddedInput = screen.getByLabelText("Date Added(iso format)");
+    expect(dateAddedInput).toBeInTheDocument();
+
+    const createButton = screen.getByText("Create");
+    expect(createButton).toBeInTheDocument();
+
+    
+
+    fireEvent.change(titleInput, {
+      target: { value: "Why are there so many daffodils in Jersey?" },
+    });
+    fireEvent.change(urlInput, {
+      target: { value: "https://www.bbc.com/news/articles/cx2l20rwxgxo" },
+    });
+    fireEvent.change(emailInput, {
+      target: { value: "prishabobde@gmail.com" },
+    });
+    fireEvent.change(explanationInput, {
+      target: { value: "Explaining the daffodil bloom" },
+    });
+    fireEvent.change(dateAddedInput, {
+      target: { value: "2024-12-12T05:06:05" },
+    });
+    fireEvent.click(createButton);
+
+    //fireEvent.submit(screen.getByTestId("ArticleForm-title").closest("form"));
+
+
+    await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+    expect(axiosMock.history.post[0].params).toEqual({
+      title: "Why are there so many daffodils in Jersey?",
+      url: "https://www.bbc.com/news/articles/cx2l20rwxgxo",
+      explanation: "Explaining the daffodil bloom",
+      email: "prishabobde@gmail.com",
+      dateAdded: "2024-12-12T05:06:05.000",
+    });
+
+    // assert - check that the toast was called with the expected message
+    expect(mockToast).toHaveBeenCalledWith(
+      "New article Created - id: 7 title: Why are there so many daffodils in Jersey?",
+    );
+    expect(mockNavigate).toHaveBeenCalledWith({ to: "/articles" });
   });
 });

--- a/frontend/src/tests/pages/Articles/ArticlesCreatePage.test.jsx
+++ b/frontend/src/tests/pages/Articles/ArticlesCreatePage.test.jsx
@@ -60,7 +60,6 @@ describe("ArticleCreatePage tests", () => {
     });
   });
 
-
   test("on submit, makes request to backend, and redirects to /articles", async () => {
     const queryClient = new QueryClient();
     const article = {
@@ -104,8 +103,6 @@ describe("ArticleCreatePage tests", () => {
     const createButton = screen.getByText("Create");
     expect(createButton).toBeInTheDocument();
 
-    
-
     fireEvent.change(titleInput, {
       target: { value: "Why are there so many daffodils in Jersey?" },
     });
@@ -124,7 +121,6 @@ describe("ArticleCreatePage tests", () => {
     fireEvent.click(createButton);
 
     //fireEvent.submit(screen.getByTestId("ArticleForm-title").closest("form"));
-
 
     await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
 


### PR DESCRIPTION
Closes #52

In this PR, we replace placeholder Article Create Page with a working Create page for Articles. 

# To test
1. login to dokku instance: https://team02-dev-prishabobde.dokku-06.cs.ucsb.edu/
2. navigate to create page for Articles
3. fill in the fields
4. Click create
5. check the /api/articles/all endpoint with Swagger to see if the new record is in the database


Storybook:
https://69f542c1da16dc378603b48d-nycdrzcpul.chromatic.com/?path=/story/pages-articles-articlecreatepage--default

<img width="1390" height="696" alt="Screenshot 2026-05-05 at 3 45 12 PM" src="https://github.com/user-attachments/assets/65a0ead7-8f0c-4e3a-b2de-0420e67e567f" />


