### PR TITLE
add e2e tests for UCSBDiningCommonsMenuItemWeb

### DIFF
--- a/src/test/java/edu/ucsb/cs156/example/web/UCSBDiningCommonsMenuItemWebIT.java
+++ b/src/test/java/edu/ucsb/cs156/example/web/UCSBDiningCommonsMenuItemWebIT.java
@@ -1,0 +1,49 @@
+package edu.ucsb.cs156.example.web;
+
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+
+import edu.ucsb.cs156.example.WebTestCase;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+@ActiveProfiles("integration")
+@DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
+public class UCSBDiningCommonsMenuItemWebIT extends WebTestCase {
+  @Test
+  public void admin_user_can_create_edit_delete_menu_item() throws Exception {
+    setupUser(true);
+
+    page.getByText("Menu Items").click();
+
+    page.getByText("Create Menu Item").click();
+    assertThat(page.getByText("Create new Dining Commons Menu Item")).isVisible();
+    page.getByTestId("UCSBDiningCommonsMenuItem-diningCommonsCode").fill("ortega");
+    page.getByTestId("UCSBDiningCommonsMenuItem-name").fill("Chicken Burrito");
+    page.getByTestId("UCSBDiningCommonsMenuItem-station").fill("Entrees");
+    page.getByTestId("UCSBDiningCommonsMenuItem-submit").click();
+
+    assertThat(page.getByTestId("UCSBDiningCommonsMenuItemTable-cell-row-0-col-diningCommonsCode"))
+        .hasText("ortega");
+
+    page.getByTestId("UCSBDiningCommonsMenuItemTable-cell-row-0-col-Edit-button").click();
+    assertThat(page.getByText("Edit UCSBDiningCommonsMenuItem")).isVisible();
+    page.getByTestId("UCSBDiningCommonsMenuItem-name").fill("Veggie Burrito");
+    page.getByTestId("UCSBDiningCommonsMenuItem-submit").click();
+
+    assertThat(page.getByTestId("UCSBDiningCommonsMenuItemTable-cell-row-0-col-name"))
+        .hasText("Veggie Burrito");
+
+    page.getByTestId("UCSBDiningCommonsMenuItemTable-cell-row-0-col-Delete-button").click();
+
+    assertThat(page.getByTestId("UCSBDiningCommonsMenuItemTable-cell-row-0-col-name"))
+        .not()
+        .isVisible();
+  }
+}


### PR DESCRIPTION
closes #136 
adds E2E tests for UCSBDiningCommonsMenuItem
To test: run the tests locally and ensure they are both correct and 100% passs.